### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/configs/validator.py
+++ b/configs/validator.py
@@ -4,6 +4,7 @@ import os
 import yaml
 import jsonschema
 from pathlib import Path
+from urllib.parse import urlparse
 from .auth_manager import validate_auth_config_schema
 from .api_providers import validate_provider_config
 
@@ -301,8 +302,8 @@ def get_configuration_recommendations(config):
     # Check for proxy configuration in enterprise scenarios
     providers = config.get('providers', {})
     has_cloud_providers = any(
-        'api.openai.com' in provider.get('base_url', '') or
-        'api.anthropic.com' in provider.get('base_url', '')
+        urlparse(provider.get('base_url', '')).hostname == 'api.openai.com' or
+        urlparse(provider.get('base_url', '')).hostname == 'api.anthropic.com'
         for provider in providers.values()
     )
     


### PR DESCRIPTION
Potential fix for [https://github.com/tcpiplab/AblitaFuzzer/security/code-scanning/2](https://github.com/tcpiplab/AblitaFuzzer/security/code-scanning/2)

To properly identify cloud providers by hostname, parse the `base_url` using `urllib.parse.urlparse`, then inspect the `hostname` property rather than doing a substring match.  
- For both OpenAI and Anthropic checks, use `urlparse(provider.get('base_url', '')).hostname` and confirm the hostname matches the expected value (`api.openai.com` or `api.anthropic.com`).  
- Edit the code at lines 304–305 in `configs/validator.py` so the check works on the parsed hostname, not substring.  
- Add the required import: `from urllib.parse import urlparse`, if not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
